### PR TITLE
Added optional redis layer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,8 @@
 coverage.xml
 venv/
 env/
+.mypy_cache
+.vscode
 
 build
 dist/

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Add groups, channels or send messages
 
 ```python
 async def on_receive(self, websocket, data):
-    self.channel_layer.add(group, self.channel)
+    await self.channel_layer.add(group, self.channel)
 
     await self.channel_layer.group_send(group, "Welcome !")
 ```
@@ -54,7 +54,7 @@ Finnaly, remove the channel once the connection is closed
 
 ```python
 async def on_disconnect(self, websocket, close_code):
-    self.channel_layer.remove_channel(self.channel)
+    await self.channel_layer.remove_channel(self.channel)
 ```
 
 
@@ -78,7 +78,7 @@ class Chat(WebSocketEndpoint):
         if message.strip():
             group = f"group_{room_id}"
 
-            self.channel_layer.add(group, self.channel)
+            await self.channel_layer.add(group, self.channel)
 
             payload = {
                 "username": username,
@@ -92,14 +92,14 @@ class Chat(WebSocketEndpoint):
 
 The `ChannelLayer` class provided by `nejma` exposes the following methods :
 
-`add(group, channel, send=None)`
+`async add(group, channel, send=None)`
 
 Adds a channel to a giving group.
 
 * send : method to send messages to a channel
 
 ```python
-self.channel_layer.add(group, self.channel, send=websocket.send)
+await self.channel_layer.add(group, self.channel, send=websocket.send)
 ```
 
 `async group_send(group, "Welcome !")`
@@ -110,26 +110,26 @@ Sends a message to a group of channels
 await self.channel_layer.group_send(group, "Welcome !")
 ```
 
-`remove(group, channel)`
+`async remove(group, channel)`
 
 Removes a channel from a given group
 
 ```python
-self.channel_layer.remove(group, self.channel)
+await self.channel_layer.remove(group, self.channel)
 ```
 
-`remove_channel(channel)`
+`async remove_channel(channel)`
 
 Removes a channel from all the groups
 
 ```python
-self.channel_layer.remove_channel(self.channel)
+await self.channel_layer.remove_channel(self.channel)
 ```
 
-`flush()`
+`async flush()`
 
 Reset all the groups
 
 ```python
-self.channel_layer.flush()
+await self.channel_layer.flush()
 ```

--- a/nejma/ext/starlette/endpoints.py
+++ b/nejma/ext/starlette/endpoints.py
@@ -6,6 +6,7 @@ from nejma.layers import Channel, channel_layer
 
 class WebSocketEndpoint(BaseWebSocketEndpoint):
     encoding = "json"
+    channel_layer = channel_layer
 
     async def on_connect(self, websocket, **kwargs):
         await super().on_connect(websocket, **kwargs)
@@ -18,7 +19,7 @@ class WebSocketEndpoint(BaseWebSocketEndpoint):
             send_ = websocket.send_bytes
         else:
             send_ = websocket.send
-        self.channel = Channel()
+        self.channel = Channel(send=send_)
         self.channel_layer.send = send_
 
     async def on_disconnect(self, websocket, close_code):

--- a/nejma/ext/starlette/endpoints.py
+++ b/nejma/ext/starlette/endpoints.py
@@ -10,7 +10,6 @@ class WebSocketEndpoint(BaseWebSocketEndpoint):
     async def on_connect(self, websocket, **kwargs):
         await super().on_connect(websocket, **kwargs)
 
-        self.channel_layer = channel_layer
         if self.encoding == "json":
             send_ = websocket.send_json
         elif self.encoding == "text":
@@ -19,8 +18,8 @@ class WebSocketEndpoint(BaseWebSocketEndpoint):
             send_ = websocket.send_bytes
         else:
             send_ = websocket.send
-
-        self.channel = Channel(send=send_)
+        self.channel = Channel()
+        self.channel_layer.send = send_
 
     async def on_disconnect(self, websocket, close_code):
-        self.channel_layer.remove_channel(self.channel)
+        await self.channel_layer.remove_channel(self.channel)

--- a/nejma/layers.py
+++ b/nejma/layers.py
@@ -2,6 +2,11 @@ import re
 import random
 import string
 import time
+# optional dependency
+try:
+    import aioredis
+except ImportError:
+    aioredis = None
 
 
 class Channel:
@@ -79,6 +84,59 @@ class ChannelLayer:
             for channel in list(self.groups.get(group, {})):
                 if channel.is_expired():
                     del self.groups[group][channel]
+
+
+class RedisLayer(ChannelLayer):
+    def __init__(self, redis_host="redis://localhost", prefix="group"):
+        self.initialized = False
+        self.send = None
+        self.redis_host = redis_host
+        self.prefix = prefix
+
+    ### utility functions ###
+
+    def group_prefix(self, group):
+        return f"{self.prefix}_{group}" if not group.startswith(
+            f"{self.prefix}_") else f"{group}"
+
+    async def _initialize(self):
+        self.redis: aioredis.Redis = await aioredis.create_redis(self.redis_host)
+        self.initialized = True
+
+    ### add/remove interface ###
+
+    async def add(self, group_name, channel, send=None):
+        if not self.initialized:
+            await self._initialize()
+        assert self.validate_name(group_name), "Invalid group name"
+        if isinstance(channel, Channel):
+            channel = channel.name
+        group_name = self.group_prefix(group_name)
+        await self.redis.hset(group_name, channel, 1)
+
+    async def remove_channel(self, channel):
+        if not self.initialized:
+            await self._initialize()
+        if isinstance(channel, Channel):
+            channel = channel.name
+        cur, keys = await self.redis.scan(match=self.group_prefix("*"))
+        for key in keys:
+            await self.redis.hdel(key, channel)
+
+    async def remove(self, group_name, channel):
+        if not self.initialized:
+            await self._initialize()
+        group_name = self.group_prefix(group_name)
+        await self.redis.hdel(group_name, channel)
+
+    # send interface
+
+    async def group_send(self, group, payload):
+        if not self.initialized:
+            await self._initialize()
+        group_name = self.group_prefix(group)
+        for i in await self.redis.hgetall(group_name):
+            await Channel(send=self.send).send(payload)
 
 
 channel_layer = ChannelLayer()

--- a/nejma/layers.py
+++ b/nejma/layers.py
@@ -96,6 +96,7 @@ class RedisLayer(ChannelLayer):
     ### utility functions ###
 
     def group_prefix(self, group):
+        group = str(group)
         return f"{self.prefix}_{group}" if not group.startswith(
             f"{self.prefix}_") else f"{group}"
 

--- a/nejma/layers.py
+++ b/nejma/layers.py
@@ -111,7 +111,6 @@ class RedisLayer(ChannelLayer):
     async def add(self, group_name, channel, send=None):
         if not self.initialized:
             await self._initialize()
-        assert self.validate_name(group_name), "Invalid group name"
         if isinstance(channel, Channel):
             channel = channel.name
         group_name = self.group_prefix(group_name)

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,9 @@ import setuptools
 
 def get_version(package):
     with open(os.path.join(package, "__version__.py")) as f:
-        return re.search("__version__ = ['\"]([^'\"]+)['\"]", f.read()).group(1)
+        return re.search(
+            "__version__ = ['\"]([^'\"]+)['\"]",
+            f.read()).group(1)
 
 
 def get_readme():
@@ -26,6 +28,7 @@ setuptools.setup(
     author_email="abacidtaoufik@gmail.com",
     packages=setuptools.find_packages(),
     python_requires=">=3.6",
+    extras_require={"redis": ["aioredis"]},
     classifiers=[
         "Environment :: Web Environment",
         "Intended Audience :: Developers",


### PR DESCRIPTION
This pull requests adds RedisLayer class.
As starlette endpoint was hardcoded to use default one, now it is possible to select one by setting class attribute.
To install redis layer, it is needed to install optional dependency i.e.:
`pip install nejma[redis]`
I think that all functions(except for utility ones) should become asyncronous.
What's the point in having most functions async and only add function sync for example?
This pull request is probably not yet ready to merge as some compatibility changes should be decided.